### PR TITLE
Minor fixes to charter text, and remaining issues

### DIFF
--- a/i18n-ig/charter.html
+++ b/i18n-ig/charter.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
   <meta charset="utf-8" />
-  <title>Internationalization IG charter (draft)</title>
+  <title>Internationalization Interest Group (I18n IG) charter (draft)</title>
   <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css"
   type="text/css" media="screen" />
   <link rel="stylesheet" type="text/css"
@@ -29,14 +29,14 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /> </a> <a class="domainlogo"
 href="https://www.w3.org/Interaction/" shape="rect"><img src="https://www.w3.org/Icons/interaction"
 alt="Interaction Domain" /> </a></p>
 
-<h1 id="title">Internationalization (I18n) Interest Group Charter (Draft)</h1>
+<h1 id="title">Internationalization Interest Group (I18n IG) Charter (Draft)</h1>
 
 <p class="mission">The <strong>mission</strong> of the <a
 href="https://w3c.github.io/i18n-activity/i18n-ig/">Internationalization
 (I18n) Interest Group</a>, part of the <a
 href="https://www.w3.org/International/">Internationalization Activity</a>, is
-to help the Working Groups within the Internationalization Activity and
-provides a forum to discuss issues related to the internationalization of the
+to help the Working Groups within the Internationalization Activity and to
+provide a forum to discuss issues related to the internationalization of the
 Web.</p>
 <!--<div class="noprint">
     <p class="join"><a href="https://www.w3.org/2004/11/i18n-recharter/ig-charter">Join the
@@ -56,11 +56,11 @@ Web.</p>
         shape="rect">public</a></td>
     </tr>
     <tr>
-      <th rowspan="1" colspan="1">Initial Chairs</th>
+      <th rowspan="1" colspan="1">Initial Chair</th>
       <td rowspan="1" colspan="1">Martin Dürst</td>
     </tr>
     <tr>
-      <th rowspan="1" colspan="1">Initial Team Contacts<br />
+      <th rowspan="1" colspan="1">Initial Team Contact<br />
         (FTE %: 3)</th>
       <td rowspan="1" colspan="1">Richard Ishida</td>
     </tr>
@@ -77,7 +77,7 @@ Web.</p>
 
 <p>The Interest Group helps the Working Groups within the Internationalization
 Activity with advice and opinions from a larger group of people with knowledge
-in different languages and cultures as well as different parts of the Web
+in different languages and cultures as well as different aspects of Web
 architecture. The Interest Group also provides a forum to discuss issues
 related to the internationalization of the Web.</p>
 <p>The Interest Group also allows IG participants to come together in task forces to investigate specific aspects of international support for the Web. Any documents produced by these task forces are published by the Internationalization Working Group.</p>
@@ -86,19 +86,19 @@ related to the internationalization of the Web.</p>
 <div>
 <h2 id="deliverables">Deliverables</h2>
 
-<p>This Interest Group does not produce any deliverables.</p>
+<p>The Interest Group does not produce any deliverables.</p>
 </div>
 
 <div class="dependencies">
 <h2 id="coordination">Dependencies</h2>
 
 <p>The Internationalization Interest Group  provides a forum for
-announcements, discussion and advice for each of the Working Groups in the
+announcements, discussion and advice for the Working Groups in the
 Internationalization Activity. Members of all Internationalization Working
-Groups will be automatically subscribed to the Internationalization Interest
+Groups are automatically subscribed to the Internationalization Interest
 Group. The WGs will use the i18n IG to obtain input from a larger group of
 people with knowledge in different languages and cultures as well as different
-parts of the Web architecture, and to report progress on their work, and
+aspects of Web architecture, and to report progress on their work, and
 solicit feedback.</p>
 </div>
 
@@ -109,10 +109,10 @@ solicit feedback.</p>
 W3C Membership is not a prerequisite.</p>
 
 <p>Membership of the IG is signified by subscribing to the mailing list,
-www-international@w3.org. One can subscribe to the mailing list by sending an
+www-international@w3.org. To subscribe to the mailing list, send an
 email to www-international-request@w3.org, with 'subscribe' in the Subject.
 There is no time commitment for participation in the Interest Group.</p>
-<p>There may be more specific criteria for participation in any task forces of the IG, that are defined by the informative charter for that task force.</p>
+<p>There may be more specific criteria for participation in any task forces of the IG. These criteria are defined by the informative charter for that task force.</p>
 </div>
 
 <div class="communication">


### PR DESCRIPTION
There are some issues still remaining:
1.    Who can initiate or block task forces (if we aren't careful, we might get lots of proposals, or people who claim they want a task force and we can't deny it)
2.   What will happen with the "previous link" next time the charter is updated? (another problem with moving to github)
3.    It would be good to have a pointer to a list of the specialized mailing lists ("specialised mailing lists for topics such as bidi, indic, cjk, etc") and a pointer to current and past (and maybe potential/planned) task forces
