### PR TITLE
Update CSS/JS links to HTTPS

### DIFF
--- a/drafts/vertical-text/tests/chinese-forms.html
+++ b/drafts/vertical-text/tests/chinese-forms.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>Chinese forms, user tests</title>
-<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 <style type="text/css">
 @font-face {
     font-family: 'Noto Sans Mongolian WF';

--- a/drafts/vertical-text/tests/chinese-lists.html
+++ b/drafts/vertical-text/tests/chinese-lists.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>Chinese lists, user tests</title>
-<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 <style type="text/css">
 @font-face {
     font-family: 'Noto Sans Mongolian WF';

--- a/drafts/vertical-text/tests/chinese-table.html
+++ b/drafts/vertical-text/tests/chinese-table.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>Chinese tables, user tests</title>
-<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 <style type="text/css">
 @font-face {
     font-family: 'Noto Sans Mongolian WF';

--- a/drafts/vertical-text/tests/chinese.html
+++ b/drafts/vertical-text/tests/chinese.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <title>writing mode user tests</title>
 <title>Chinese vertical text, user tests</title>
-<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 <style type="text/css">
 @font-face {
     font-family: 'Noto Sans Mongolian WF';

--- a/drafts/vertical-text/tests/mongolian-forms.html
+++ b/drafts/vertical-text/tests/mongolian-forms.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>Mongolian forms, user tests</title>
-<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 <style type="text/css">
 @font-face {
     font-family: 'Noto Sans Mongolian WF';

--- a/drafts/vertical-text/tests/mongolian-lists.html
+++ b/drafts/vertical-text/tests/mongolian-lists.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>Mongolian lists, user tests</title>
-<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 <style type="text/css">
 @font-face {
     font-family: 'Noto Sans Mongolian WF';

--- a/drafts/vertical-text/tests/mongolian-table.html
+++ b/drafts/vertical-text/tests/mongolian-table.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>Mongolian tables, user tests</title>
-<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 <style type="text/css">
 @font-face {
     font-family: 'Noto Sans Mongolian WF';

--- a/drafts/vertical-text/tests/mongolian.html
+++ b/drafts/vertical-text/tests/mongolian.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>Mongolian vertical text, user tests</title>
-<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 <style type="text/css">
 @font-face {
     font-family: 'Noto Sans Mongolian WF';

--- a/editorial-guidelines/index.html
+++ b/editorial-guidelines/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>Github basics for i18n documents</title>
-<link rel="stylesheet" type="text/css" href="http://www.w3.org/International/style/article-display-2016.css" />
+<link rel="stylesheet" type="text/css" href="https://www.w3.org/International/style/article-display-2016.css" />
 <style type="text/css">
 /*
 small p, small address {


### PR DESCRIPTION
Fixing the problem of HTTPS HTML pages trying to load CSS/JS over HTTP.

<img width="1326" alt="screen shot 2016-01-21 at 11 16 22 am" src="https://cloud.githubusercontent.com/assets/37169/12491522/6e96d14c-c030-11e5-8287-9bfa3406431b.png">
