### PR TITLE
Enhancing color contrast for headings

### DIFF
--- a/style/homepage.css
+++ b/style/homepage.css
@@ -108,11 +108,12 @@ h2 {
     border-radius: 10px;
 	}
 h2 a:link, h2 a:visited {
-	color: white;
+	color: inherit;
 	}
 
 .directory h2 {
-    background-color: #EEB058;
+	color: #000;
+    	background-color: #EEB058;
 	}
 
 .panel {


### PR DESCRIPTION
Previously: #fff on  #EEB058 ➡ contrast ratio 1.91 (3 recommended for large text). Darkening the yellow background color (to #c58900) is ugly. With black text, the contrast is 10.99 and more than enough.

(Also made the link inherit the color of the heading text to avoid duplicate declarations.)
