### PR TITLE
updated link from http: to https: for w3.org, w3c.github.io

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -203,12 +203,12 @@ For each work item, the page describes objectives <!--and next steps (the number
       
  <div class="item" id="africa">
 <p class="topic">africa</p>
-<p><a target="_blank" href="https://github.com/w3c/afrlreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=afrlreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/afrlreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=afrlreq">issue summary</a></p>
 </div>
 
      <div class="item" id="arabic">
       <p class="topic">arabic</p>
-        <p><a target="_blank" href="https://github.com/w3c/alreq/">GH repo</a> • <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=alreq">issue summary</a></p>
+        <p><a target="_blank" href="https://github.com/w3c/alreq/">GH repo</a> • <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=alreq">issue summary</a></p>
 <ol class="todo">
 <li class="inprogress">add content</li>
           <li>send for reviews</li>
@@ -217,7 +217,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
 <div class="item" id="chinese">
 <p class="topic">chinese</p>
-<p><a target="_blank" href="https://github.com/w3c/clreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=clreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/clreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=clreq">issue summary</a></p>
 <ol class="todo">
 <li class="inprogress">complete translation to SC</li>
 <li>address outstanding issues</li>
@@ -226,7 +226,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
 <div class="item" id="ethiopic">
 <p class="topic">ethiopic</p>
-<p><a target="_blank" href="https://github.com/w3c/elreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=elreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/elreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=elreq">issue summary</a></p>
 <ol class="todo">
 <li class="inprogress">get review of FPWD</li>
 <li>add further content</li>
@@ -235,12 +235,12 @@ For each work item, the page describes objectives <!--and next steps (the number
  
  <div class="item" id="europe">
 <p class="topic">europe</p>
-<p><a target="_blank" href="https://github.com/w3c/eurlreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=eurlreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/eurlreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=eurlreq">issue summary</a></p>
 </div>
 
 <div class="item" id="hebrew">
 <p class="topic">hebrew</p>
-<p><a target="_blank" href="https://github.com/w3c/hlreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=hlreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/hlreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=hlreq">issue summary</a></p>
 <ol class="todo">
 <li class="inprogress">set up group</li>
 <li>send for reviews</li>
@@ -249,7 +249,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
 <div class="item" id="indic">
 <p class="topic">indic (s asian)</p>
-<p><a target="_blank" href="https://github.com/w3c/iip/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=ilreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/iip/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=ilreq">issue summary</a></p>
 <ol class="todo">
 <li class="inprogress">revitalise the work</li>
 <li class="inprogress">expand coverage of languages beyond Hindi</li>
@@ -258,7 +258,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
 <div class="item" id="japanese">
 <p class="topic">japanese</p>
-          <p><a target="_blank" href="https://github.com/w3c/jlreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=jlreq">issue summary</a></p>
+          <p><a target="_blank" href="https://github.com/w3c/jlreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=jlreq">issue summary</a></p>
 <ol class="todo">
 <li class="inprogress">update with errata</li>
             <li>publish updated Note</li>
@@ -266,7 +266,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
 <div class="item" id="korean">
 <p class="topic">korean</p>
-<p><a target="_blank" href="https://github.com/w3c/klreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=klreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/klreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=klreq">issue summary</a></p>
 <ol class="todo">
 <li>address outstanding issues</li>
 <li>publish new WD</li>
@@ -274,7 +274,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
 <div class="item" id="mongolian">
 <p class="topic">mongolian</p>
-<p><a target="_blank" href="https://github.com/w3c/mlreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=mlreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/mlreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=mlreq">issue summary</a></p>
 <ol class="todo">
 <li>support discussions on mongolian variants</li>
 <li>ask experts about requirements when needed and capture them</li>
@@ -282,7 +282,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
 <div class="item" id="mongolian2">
 <p class="topic">se asia</p>
-<p><a target="_blank" href="https://github.com/w3c/sealreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=sealreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/sealreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=sealreq">issue summary</a></p>
 <ol class="todo">
 <li>support discussions on mongolian variants</li>
 <li>ask experts about requirements when needed and capture them</li>
@@ -290,7 +290,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
         <div class="item" id="tibetan">
         <p class="topic">tibetan</p>
-<p><a target="_blank" href="https://github.com/w3c/tlreq/">GH repo</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/textlayout/?filter=tlreq">issue summary</a></p>
+<p><a target="_blank" href="https://github.com/w3c/tlreq/">GH repo</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/textlayout/?filter=tlreq">issue summary</a></p>
 <ol class="todo">
 <li class="inprogress">Chunming to translate en to zh</li>
             <li class="inprogress">do initial review</li>
@@ -357,7 +357,7 @@ For each work item, the page describes objectives <!--and next steps (the number
       <div class="item" id="reviews">
       <p class="topic">reviews</p>
         <p><a target="_blank" href="https://github.com/w3c/i18n-activity/projects/1">radar</a> &bull; 
-        <a target="_blank" href="http://w3c.github.io/i18n-activity/reviews/">issue tracker</a></p>
+        <a target="_blank" href="https://w3c.github.io/i18n-activity/reviews/">issue tracker</a></p>
         <ul class="objectives">
           <li> Review specifications for W3C and other working group for internationalization issues.</li>
         </ul>
@@ -395,7 +395,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
       <div class="item" id="tests">
         <p class="topic">tests</p>
-        <p><a target="_blank" href="http://www.w3.org/International/tests">test suite</a></p>
+        <p><a target="_blank" href="https://www.w3.org/International/tests">test suite</a></p>
         <ul class="objectives">
           <li>Produce tests for i18n features of browsers, especially for upcoming CSS features. Add summaries of the results on latest UA versions. Develop notes on current implementation status.<br>
           </li>
@@ -408,7 +408,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
       <div class="item" id="ruby_impl">
         <p class="topic"> implementer support</p>
-        <p><a target="_blank" href="http://www.w3.org/International/tests">test suite</a> • <a href="http://w3c.github.io/i18n-activity/reviews/#browser-implementations">bug tracker</a></p>
+        <p><a target="_blank" href="https://www.w3.org/International/tests">test suite</a> • <a href="https://w3c.github.io/i18n-activity/reviews/#browser-implementations">bug tracker</a></p>
         <ul class="objectives1">
           <li>Assess and track implementations of i18n features, and offer advice to implementers.</li>
         </ul>
@@ -439,7 +439,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div-->
 <div class="item" id="strings">
 <p class="topic"> string metadata</p>
-          <p><a target="_blank" href="https://w3c.github.io/string-meta/">note</a> • <a target="_blank" href="http://w3c.github.io/i18n-discuss/notes/i18n-action-612.html">issue doc</a> • <a href="https://github.com/w3ctag/design-reviews/issues/178">tag discn</a></p>
+          <p><a target="_blank" href="https://w3c.github.io/string-meta/">note</a> • <a target="_blank" href="https://w3c.github.io/i18n-discuss/notes/i18n-action-612.html">issue doc</a> • <a href="https://github.com/w3ctag/design-reviews/issues/178">tag discn</a></p>
           <ul class="objectives1">
             <li> Develop requirements and best practices for handling language and direction with strings in plain text and JSON, data formats, etc.</li>
           </ul>
@@ -476,7 +476,7 @@ For each work item, the page describes objectives <!--and next steps (the number
 </div>
         <div class="item" id="locales">
           <p class="topic">locales and locale-affected formats</p>
-          <p><a target="_blank" href="http://w3c.github.io/ltli/">ED</a> &bull; <a target="_blank" href="https://github.com/w3c/ltli/">GH</a> &bull; <a target="_blank" href="https://www.w3.org/International/wiki/Locale-based_forms">wiki</a></p>
+          <p><a target="_blank" href="https://w3c.github.io/ltli/">ED</a> &bull; <a target="_blank" href="https://github.com/w3c/ltli/">GH</a> &bull; <a target="_blank" href="https://www.w3.org/International/wiki/Locale-based_forms">wiki</a></p>
           <ul class="objectives">
             <li> Produce guidelines for working with locale-specific features in the Open Web Platform.</li>
           </ul>
@@ -494,7 +494,7 @@ For each work item, the page describes objectives <!--and next steps (the number
       
     <div class="item" id="articles">
       <p class="topic">articles</p>
-        <p><a href="https://github.com/w3c/i18n-drafts/projects/1">article pipeline</a> &bull; <a target="_blank" href="http://w3c.github.io/i18n-activity/repostatus/">issue tracker</a> &bull; 
+        <p><a href="https://github.com/w3c/i18n-drafts/projects/1">article pipeline</a> &bull; <a target="_blank" href="https://w3c.github.io/i18n-activity/repostatus/">issue tracker</a> &bull; 
         <a target="_blank" href="https://www.w3.org/International/articlelist">article list</a></p>
         <ul class="objectives">
           <li> Develop articles and tutorials to assist content authors and others to apply internationalization features in W3C standards.</li>
@@ -588,7 +588,7 @@ For each work item, the page describes objectives <!--and next steps (the number
     <tr>
       <td>
       	<p class="topic">unicode</p>
-        <p><a target="_blank" href="http://www.unicode.org">site</a></p>
+        <p><a target="_blank" href="https://www.unicode.org">site</a></p>
         <ol class="todo">
           <li>track developments</li>
         </ol>
@@ -604,7 +604,7 @@ For each work item, the page describes objectives <!--and next steps (the number
         
       <td>
       	<p class="topic">unicode</p>
-        <p><a target="_blank" href="http://www.unicode.org">site</a></p>
+        <p><a target="_blank" href="https://www.unicode.org">site</a></p>
         <ol class="todo">
           <li>track developments</li>
         </ol>
@@ -629,7 +629,7 @@ For each work item, the page describes objectives <!--and next steps (the number
     <tr>
       <td>
         <p class="topic">ontolex cg</p>
-        <p><a target="_blank" href="http://www.w3.org/community/ontolex/">home</a> &bull; <a target="_blank" href="https://www.w3.org/community/ontolex/wiki/Final_Model_Specification">spec</a></p>
+        <p><a target="_blank" href="https://www.w3.org/community/ontolex/">home</a> &bull; <a target="_blank" href="https://www.w3.org/community/ontolex/wiki/Final_Model_Specification">spec</a></p>
         <ul>
           <li>define an ontology lexicon model for the Web</li>
         </ul></td>


### PR DESCRIPTION
switching link target from http to https for w3.org and w3c.github.io in projects/
(original motivation was to fix page security warning for mixed contents...)