### PR TITLE
dead link

### DIFF
--- a/guidelines/github.html
+++ b/guidelines/github.html
@@ -82,7 +82,7 @@ pre { margin-left: 7.5%; }
 <h1>Github guidelines for working with i18n documents</h1>
 </header>
 <section>
-  <p>The W3C Internationalization Activity has task forces which use github for document development. This page provides guidelines to help people contribute content if they are unfamiliar with github. Some of this information is a shameless copy of text  from <a href="http://testthewebforward.org/docs/github-101.html">the Test the Web Forward documentation</a>.</p>
+  <p>The W3C Internationalization Activity has task forces which use github for document development. This page provides guidelines to help people contribute content if they are unfamiliar with github. Some of this information is a shameless copy of text  from <a href="http://web-platform-tests.org/writing-tests/github-intro.html">the Test the Web Forward documentation</a>.</p>
 <p>For the examples we will use the github username <span class="highlightedterm">myUserName</span> and we'll use a  repository (repo) name, <span class="highlightedterm">repoName</span>. You should substitute your own username wherever you see <span class="qterm">myUserName</span>, and the name of the repo you want to work with for <span class="qterm">repoName</span>.</p>
 <p>If you have comments or suggestions about how to improve this page, feel free to <a href="https://github.com/w3c/i18n-activity/issues">raise a Github issue</a>.</p>
 <p>See also the <a href="editing">editorial guidelines</a>.</p>


### PR DESCRIPTION
http://testthewebforward.org/docs/github-101.html
is dead
correct link is now
http://web-platform-tests.org/writing-tests/github-intro.html