### PR TITLE
jump to specified position by hash, for environment with slow loading

### DIFF
--- a/reviews/index.html
+++ b/reviews/index.html
@@ -140,6 +140,10 @@ var maxpages = 5
 							}
 						
 						checkDates()
+                        // jump to hash position after tree built
+                        if (document.location.hash) {
+                            var chash = document.location.hash;
+                            document.location.hash = chash;
 						}
 					else if (debug) console.log('Counter',counter)
 					}, 50)


### PR DESCRIPTION
We can set position of display with hash in URL for sharing, but in some environment with e.g. slow loading, html with lists of fetched issue (h2 with table) will be build after display/jump operation finished - which causes hash not to be found and display kept at the top.
Re-adding hash after processing on list of issues by this PR could fix this.