### PR TITLE
Use 2022 template

### DIFF
--- a/guidelines/editing.html
+++ b/guidelines/editing.html
@@ -111,9 +111,9 @@ table td {
 <p>New site pages must include the following:</p>
 
 <ol>
-<li>/i18n-drafts/javascript/doc-structure/sitepage.js</li>
-<li>/i18n-drafts/javascript/articletoc-html5.js</li>
-<li>/i18n-drafts/style/sitepage-2016.css</li>
+<li>/i18n-drafts/javascript/doc-structure/sitepage-2022.js</li>
+<li>/i18n-drafts/javascript/articletoc-2022.js</li>
+<li>/i18n-drafts/style/sitepage-2022.css</li>
 </ol>
 
 <p>New articles and site pages with syntax highlighting must include the following:</p>


### PR DESCRIPTION
Update the [general markup guidelines](https://www.w3.org/International/i18n-activity/guidelines/editing#othermarkup) to use 2022 template.

Please check if this is correct.