### PR TITLE
Update the affiliation of Addison

### DIFF
--- a/i18n-wg/index.html
+++ b/i18n-wg/index.html
@@ -91,7 +91,7 @@ implementers.</p>
 <section id="organization">
 <h2>Organization</h2>
 
-<p>The chair of the Working Group is Addison Phillips (Amazon).</p>
+<p>The chair of the Working Group is Addison Phillips.</p>
 
 <p>The Working Group uses the mailing lists of the <a href="../i18n-ig/">Internationalization Interest Group</a> to disseminate notifications about ongoing work and meeting minutes.  The language enablement work of the WG is supported by repositories and task forces that are formed under the umbrella of the Interest Group. Participation in the Interest Group and its task forces is open to all who are interested.  Participation in the Working Group itself is limited to W3C members and invited experts.</p>
 </section>


### PR DESCRIPTION
Remove the affiliation to make it consistent with https://w3c.github.io/i18n-activity/i18n-ig/#organization .