### PR TITLE
editorial: adjust TC39 liaison text to refer to ECMA-402

### DIFF
--- a/i18n-wg/charter.html
+++ b/i18n-wg/charter.html
@@ -304,7 +304,7 @@ manner.</li>
   (UTC)</a></dt>
 <dd>A liaison has been established. The Internationalization WG will review Unicode Consortium publications for Web-related internationalization features, where needed.</dd>
 <dt><a href="https://tc39.es/">Ecma TC 39 (ECMAScript)</a></dt>
-<dd> We will work with Ecma TC 39 on the development of the new ECMAScript Internationalization API Specification standard and the internationalization of the ECMAScript Language Specification (ECMA-262). The ECMAScript standard defines the core of the JavaScript programming language.</dd>
+<dd> We will work with Ecma TC39 on the development of ECMA-402, the ECMAScript® Internationalization API Specification standard and the internationalization of the ECMAScript® Language Specification (ECMA-262). The ECMAScript® standard defines the core of the JavaScript™ programming language.</dd>
 <dt>Supra-national and national standards bodies</dt>
 <dd>The work of bodies such as ISO, ISO/IEC JTC1, JIS, and CEN, at
       the appropriate level (working group, subcommittee, technical


### PR DESCRIPTION
editorial: adjust TC39 liaison text with minor spacing fix and to refer to ECMA-402 by name