### PR TITLE
Update spec-generator location and properly encode url parameter

### DIFF
--- a/guidelines/github.html
+++ b/guidelines/github.html
@@ -516,7 +516,7 @@ $ git push origin gh-pages</pre>
             extension.</li>
           <li>Go to the <a href="https://labs.w3.org/pubrules/">Pubrules checker</a> and run it against the following
             URL: <br>
-            <code>https://labs.w3.org/spec-generator/?type=respec&amp;url=https://w3c.github.io/<span style="color: orange">linkToYourSpec</span>/?specStatus=WD&amp;shortName=<span style="color:orange">theShortName</span></code><br>
+            <code>https://www.w3.org/publications/spec-generator/?type=respec&amp;url=https%3A%2F%2Fw3c.github.io%2F<span style="color: orange">linkToYourSpec</span>%2F%3FspecStatus%3DWD%26shortName%3D<span style="color:orange">theShortName</span></code><br>
             Fix anything that's needed, and rerun the checker until it's ok. You will probably find that the checker
             complains about not being able to find a dependent file (usually the .css file). That's because the URL
             above creates a WD version of your main file in a new location for testing, and doesn't copy over the


### PR DESCRIPTION
This updates the base URL and path for spec-generator as per the [spec-prod announcement](https://lists.w3.org/Archives/Public/spec-prod/2025OctDec/0008.html).

This also fixes an issue with the URL in the instructions. As written, the `shortName` provided after the `url` parameter would never take effect, because it is parsed as a top-level parameter due to the `&` before it, whereas the `specStatus` and `shortName` are both intended to be parameters within the value of `url`. (This is identical to the concern I raised on https://github.com/w3c/i18n-editors/pull/109.)